### PR TITLE
Identicon for owners. Stored in datatable, and display in frontpage

### DIFF
--- a/data_reader.py
+++ b/data_reader.py
@@ -4,6 +4,9 @@ import pandas as pd
 import numpy as np
 import networkx as nx
 
+from identicon.identicon import address_to_md
+
+
 g_path = "./data"
 
 def set_buckets(df, num_buckets=4):
@@ -65,6 +68,7 @@ def load_nft_data():
         data_df['last_sale_total_price'] = data_df['last_sale_total_price'].fillna(0)
         data_df['traits_list'] = data_df['traits_list'].fillna('NoTrait')
         data_df['img_md'] = data_df['image_url'].apply(lambda url : f"<img src='{url}' height='30' />")
+        data_df['owner_img_md'] = data_df['owner_address'].apply(lambda address: address_to_md(address))
 
         prices_quantile = set_buckets(data_df, num_buckets=4)
         assign_price_buckets(data_df, prices_quantile)
@@ -77,7 +81,7 @@ def load_nft_data():
         traits_list = make_trait_list(data_df, traits_set, prices_quantile)
 
         table_df = data_df[['img_md','id','num_sales',
-                            'last_sale_total_price','name','owner_address',
+                            'last_sale_total_price','name','owner_address', 'owner_img_md',
                             'traits_sex','traits_count','traits_list']].copy()
         table_df['traits_list'] = data_df['traits_list_aslist'].apply(lambda tl : (" , ").join(tl))
     return data_df, table_df, traits_list

--- a/identicon/identicon.py
+++ b/identicon/identicon.py
@@ -1,0 +1,37 @@
+from base64 import encode
+import base64
+import pydenticon
+import hashlib
+
+
+foreground = [
+    "rgb(45,79,255)",
+    "rgb(254,180,44)",
+    "rgb(226,121,234)",
+    "rgb(30,179,253)",
+    "rgb(232,77,65)",
+    "rgb(49,203,115)",
+    "rgb(141,69,170)"
+]
+
+generator = pydenticon.Generator(
+    rows=7,
+    columns=7,
+    digest=hashlib.sha1,
+    foreground=foreground,
+    background="rgb(224,224,224)"
+)
+
+def address_to_png(address, height=30, width=30):
+    return generator.generate(
+        address,
+        height=height,
+        width=width,
+        output_format="png"
+    )
+
+def address_to_md(address, height=30, width=30):
+    encoded_image = base64.b64encode(
+        address_to_png(address, height, width)
+    ).decode("UTF-8")
+    return f"<img src='data:image/png;base64,{encoded_image}'/>"

--- a/layout/draw.py
+++ b/layout/draw.py
@@ -7,7 +7,7 @@ def makeLayout(data_df, table_df, traits_list):
     dash_table_cols = []
     for col in table_df.columns:
         col_dict = {"name": col, "id": col, "deletable": False, "selectable": False, }
-        if col in ['img_md','traits_list_list']:
+        if col in ['img_md','traits_list_list', 'owner_img_md']:
             col_dict['presentation'] = "markdown"
         dash_table_cols.append(col_dict)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,5 @@ scipy
 
 jupyter-dash
 dash-bootstrap-components
+
+pydenticon


### PR DESCRIPTION
- Need to run `pip install -r requirements.txt` and `python pickling.py` for once
- Stored in column 'owner_img_md' as a 'markdown' (`<img />` tag)
- Hopefully can put into the ownership graph and transaction graph
- pydenticon is BSD-3, need to address it in the final package