### PR TITLE
Feature/legends-etc

### DIFF
--- a/main.py
+++ b/main.py
@@ -70,7 +70,7 @@ def show_pic(hoverData_price):
             html.P(f"{', '.join(traits)}", style = {'fontSize': 8}),
             html.P(f"price : {price:.4g}", style = {'fontSize': 8}),
             html.P(f"number of sales : {num_sales}", style = {'fontSize': 8}),
-        ], style={'width': '100px', 'white-space': 'normal'})
+        ], style={'width': '100px', 'whiteSpace': 'normal'})
     ]
     #print(pt,bbox,num)
     return True, bbox, children, True, True, True, True

--- a/network/draw.py
+++ b/network/draw.py
@@ -39,7 +39,7 @@ def drawNetworkGraph(G, graph_pos, addresses = [], df = None):
         mode='markers',
         hoverinfo='text',
         marker=dict(
-            showscale=True,
+            showscale=False,  # set true to enable color scale of node
             # colorscale options
             #'Greys' | 'YlGnBu' | 'Greens' | 'YlOrRd' | 'Bluered' | 'RdBu' |
             #'Reds' | 'Blues' | 'Picnic' | 'Rainbow' | 'Portland' | 'Jet' |
@@ -72,6 +72,7 @@ def drawNetworkGraph(G, graph_pos, addresses = [], df = None):
         mode='markers',
         hoverinfo='text',
         marker=dict(
+            showscale=False,  # set true to enable color scale of node
             color='red',
             size=10,
             colorbar=dict(

--- a/prices/draw.py
+++ b/prices/draw.py
@@ -13,6 +13,7 @@ def make_price_strip_fig(df_dc):
 
     point_color = list(['blue'] * len(point_data))
     price_strip_fig = px.strip(point_data, y='last_sale_total_price', x='num_sales', color=point_color, stripmode='overlay', custom_data=['name'])
+    price_strip_fig.update_layout(showlegend=False)
 
     return price_strip_fig, point_color
 
@@ -26,6 +27,7 @@ def linkTreeChartToStripChart(hoverData, point_color, price_strip_fig, token_df_
         tokens_contain_owner = (point_data['owner_address'] == hover_label).tolist()
         updateColor = ['red' if owner else 'blue' for owner in tokens_contain_owner]
         updateStrip = px.strip(point_data, y='last_sale_total_price', x='num_sales', color=updateColor, stripmode='overlay', custom_data=['name'])
+        updateStrip.update_layout(showlegend=False)
     else:
         updateStrip = copy.deepcopy(price_strip_fig)
         updateStrip = go.Figure(updateStrip)
@@ -42,6 +44,7 @@ def linkAttrChartToStripChart(hoverData, point_color, price_strip_fig, strip_dat
         updateColor = np.array(['green' if contain_trait else updateColor[i] for i,contain_trait in enumerate(tokens_contain_trait)])
         # print(updateColor)
         updateStrip = px.strip(strip_data, y='last_sale_total_price', x='num_sales', color=updateColor, stripmode='overlay', custom_data=['name'])
+        updateStrip.update_layout(showlegend=False)
     else:
         updateStrip = copy.deepcopy(price_strip_fig)
         updateStrip = go.Figure(updateStrip)

--- a/prices/draw.py
+++ b/prices/draw.py
@@ -14,6 +14,7 @@ def make_price_strip_fig(df_dc):
     point_color = list(['blue'] * len(point_data))
     price_strip_fig = px.strip(point_data, y='last_sale_total_price', x='num_sales', color=point_color, stripmode='overlay', custom_data=['name'])
     price_strip_fig.update_layout(showlegend=False)
+    price_strip_fig.update_traces(hovertemplate="<extra></extra>")
 
     return price_strip_fig, point_color
 
@@ -28,6 +29,7 @@ def linkTreeChartToStripChart(hoverData, point_color, price_strip_fig, token_df_
         updateColor = ['red' if owner else 'blue' for owner in tokens_contain_owner]
         updateStrip = px.strip(point_data, y='last_sale_total_price', x='num_sales', color=updateColor, stripmode='overlay', custom_data=['name'])
         updateStrip.update_layout(showlegend=False)
+        updateStrip.update_traces(hovertemplate="<extra></extra>")
     else:
         updateStrip = copy.deepcopy(price_strip_fig)
         updateStrip = go.Figure(updateStrip)
@@ -45,6 +47,7 @@ def linkAttrChartToStripChart(hoverData, point_color, price_strip_fig, strip_dat
         # print(updateColor)
         updateStrip = px.strip(strip_data, y='last_sale_total_price', x='num_sales', color=updateColor, stripmode='overlay', custom_data=['name'])
         updateStrip.update_layout(showlegend=False)
+        updateStrip.update_traces(hovertemplate="<extra></extra>")
     else:
         updateStrip = copy.deepcopy(price_strip_fig)
         updateStrip = go.Figure(updateStrip)

--- a/traits/draw.py
+++ b/traits/draw.py
@@ -34,7 +34,8 @@ def price_range_graph(df, traits, num_buckets=4, interested_traits = [], traits_
                 "Price: %{x}",
                 "Proportion: %{y}",
                 "Trait: %{customdata[0]}",
-                "Rarity: %{customdata[1]}"
+                "Rarity: %{customdata[1]}",
+                "<extra></extra>"
             ]))
         data.append(go_scatter)
     fig = go.Figure(data=data)


### PR DESCRIPTION
- Removed legends in strip plot and network graph
- Removed default hover texts in strip plot and traits graph
- For the point above, <empty></empty> "hack" is suggested by [plotly](https://plotly.com/python/hover-text-and-formatting/#customizing-hover-text-with-a-hovertemplate)